### PR TITLE
feat: zero-copy IOSurface import via VK_EXT_metal_objects (#3)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ The ANGLE commit hash is pinned in two places that must stay in sync:
 ### Custom patches (applied to ANGLE source)
 1. **`0001-Skip-CPU-readback-for-IOSurface-output-path.patch`** — Bypasses CPU readback in `IOSurfaceSurfaceVkMac.mm` for GPU-only Syphon Metal data path
 2. **`0002-Enable-VK_EXT_metal_objects-device-extension-on-Appl.patch`** — Enables `VK_EXT_metal_objects` in `vk_renderer.cpp` so MTLTexture can be extracted from VkImage via MoltenVK
+3. **`0003-Support-predefined-Vulkan-border-colors-for-GL_CLAMP.patch`** — Enables `GL_EXT_texture_border_clamp` on MoltenVK by using predefined Vulkan border colors when `VK_EXT_custom_border_color` is unavailable
+4. **`0004-Import-IOSurface-backed-VkImage-via-VK_EXT_metal_obj.patch`** — Creates the IOSurface pbuffer's VkImage IOSurface-backed via `VkImportMetalIOSurfaceInfoEXT` (BGRA8, non-planar), making `bindTexImage` zero-copy; falls back to the staged upload path otherwise
 
 ### Build outputs
 - `angle/out/{Debug,Release}/libEGL.dylib` — Universal EGL library

--- a/patches/0004-Import-IOSurface-backed-VkImage-via-VK_EXT_metal_obj.patch
+++ b/patches/0004-Import-IOSurface-backed-VkImage-via-VK_EXT_metal_obj.patch
@@ -1,0 +1,197 @@
+From 2d4e76a9c610297eb9af314f04887923948c5d9a Mon Sep 17 00:00:00 2001
+From: Hiroshi Matoba <matobahiroshi@gmail.com>
+Date: Sat, 11 Jul 2026 21:52:57 +0200
+Subject: [PATCH] Import IOSurface-backed VkImage via VK_EXT_metal_objects for
+ zero-copy pbuffers
+
+Create the IOSurface pbuffer's color image with
+VkImportMetalIOSurfaceInfoEXT chained into VkImageCreateInfo, so the
+VkImage is IOSurface-backed from creation and bindTexImage needs no
+IOSurfaceLock, CPU memcpy, or vkCmdCopyBufferToImage per bind; frames
+written by the producer are visible directly.
+
+Limited to non-planar BGRA8 surfaces whose dimensions match the pbuffer.
+Any other case, robust resource init, or a driver that rejects the
+import falls back to the existing staged upload path.
+---
+ src/libANGLE/renderer/vulkan/SurfaceVk.cpp    | 15 ++--
+ src/libANGLE/renderer/vulkan/SurfaceVk.h      |  4 +-
+ .../vulkan/mac/IOSurfaceSurfaceVkMac.h        |  4 ++
+ .../vulkan/mac/IOSurfaceSurfaceVkMac.mm       | 68 +++++++++++++++++--
+ 4 files changed, 81 insertions(+), 10 deletions(-)
+
+diff --git a/src/libANGLE/renderer/vulkan/SurfaceVk.cpp b/src/libANGLE/renderer/vulkan/SurfaceVk.cpp
+index 05ffcb9..c9dbe1e 100644
+--- a/src/libANGLE/renderer/vulkan/SurfaceVk.cpp
++++ b/src/libANGLE/renderer/vulkan/SurfaceVk.cpp
+@@ -182,6 +182,8 @@ angle::Result InitImageHelper(DisplayVk *displayVk,
+                               GLint samples,
+                               bool isRobustResourceInitEnabled,
+                               bool hasProtectedContent,
++                              const void *externalImageCreateInfo,
++                              vk::ImageAccess initialAccess,
+                               vk::ImageHelper *imageHelper)
+ {
+     const angle::Format &textureFormat = vkFormat.getActualRenderableImageFormat();
+@@ -215,9 +217,9 @@ angle::Result InitImageHelper(DisplayVk *displayVk,
+         hasProtectedContent ? VK_IMAGE_CREATE_PROTECTED_BIT : vk::kVkImageCreateFlagsNone;
+     ANGLE_TRY(imageHelper->initExternal(
+         displayVk, gl::TextureType::_2D, extents, vkFormat.getIntendedFormatID(),
+-        renderableFormatId, samples, usage, imageCreateFlags, vk::ImageAccess::Undefined, nullptr,
+-        gl::LevelIndex(0), 1, 1, isRobustResourceInitEnabled, hasProtectedContent,
+-        vk::YcbcrConversionDesc{}, nullptr));
++        renderableFormatId, samples, usage, imageCreateFlags, initialAccess,
++        externalImageCreateInfo, gl::LevelIndex(0), 1, 1, isRobustResourceInitEnabled,
++        hasProtectedContent, vk::YcbcrConversionDesc{}, nullptr));
+ 
+     return angle::Result::Continue;
+ }
+@@ -631,10 +633,13 @@ angle::Result OffscreenSurfaceVk::AttachmentImage::initialize(DisplayVk *display
+                                                               const vk::Format &vkFormat,
+                                                               GLint samples,
+                                                               bool isRobustResourceInitEnabled,
+-                                                              bool hasProtectedContent)
++                                                              bool hasProtectedContent,
++                                                              const void *externalImageCreateInfo,
++                                                              vk::ImageAccess initialAccess)
+ {
+     ANGLE_TRY(InitImageHelper(displayVk, width, height, vkFormat, samples,
+-                              isRobustResourceInitEnabled, hasProtectedContent, &image));
++                              isRobustResourceInitEnabled, hasProtectedContent,
++                              externalImageCreateInfo, initialAccess, &image));
+ 
+     vk::Renderer *renderer      = displayVk->getRenderer();
+     VkMemoryPropertyFlags flags = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+diff --git a/src/libANGLE/renderer/vulkan/SurfaceVk.h b/src/libANGLE/renderer/vulkan/SurfaceVk.h
+index d786357..317f947 100644
+--- a/src/libANGLE/renderer/vulkan/SurfaceVk.h
++++ b/src/libANGLE/renderer/vulkan/SurfaceVk.h
+@@ -108,7 +108,9 @@ class OffscreenSurfaceVk : public SurfaceVk
+                                  const vk::Format &vkFormat,
+                                  GLint samples,
+                                  bool isRobustResourceInitEnabled,
+-                                 bool hasProtectedContent);
++                                 bool hasProtectedContent,
++                                 const void *externalImageCreateInfo = nullptr,
++                                 vk::ImageAccess initialAccess       = vk::ImageAccess::Undefined);
+ 
+         void destroy(const egl::Display *display);
+ 
+diff --git a/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.h b/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.h
+index c35aaff..dba884a 100644
+--- a/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.h
++++ b/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.h
+@@ -55,6 +55,10 @@ class IOSurfaceSurfaceVkMac : public OffscreenSurfaceVk
+ 
+     int mPlane;
+     int mFormatIndex;
++
++    // True when the color image was created IOSurface-backed via
++    // VK_EXT_metal_objects, making bindTexImage a no-op.
++    bool mZeroCopy = false;
+ };
+ 
+ }  // namespace rx
+diff --git a/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.mm b/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.mm
+index df1109f..ef7ff1c 100644
+--- a/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.mm
++++ b/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.mm
+@@ -20,6 +20,8 @@
+ 
+ #include <IOSurface/IOSurface.h>
+ 
++#include "vulkan/vulkan_metal.h"
++
+ namespace rx
+ {
+ 
+@@ -62,6 +64,20 @@ int FindIOSurfaceFormatIndex(GLenum internalFormat, GLenum type)
+     return -1;
+ }
+ 
++bool HasMetalObjectsExtension(vk::Renderer *renderer)
++{
++    for (const char *extensionName : renderer->getEnabledDeviceExtensions())
++    {
++        // The enabled extension list ends with a nullptr entry.
++        if (extensionName != nullptr &&
++            strcmp(extensionName, VK_EXT_METAL_OBJECTS_EXTENSION_NAME) == 0)
++        {
++            return true;
++        }
++    }
++    return false;
++}
++
+ }  // anonymous namespace
+ 
+ IOSurfaceSurfaceVkMac::IOSurfaceSurfaceVkMac(const egl::SurfaceState &state,
+@@ -118,10 +134,47 @@ int FindIOSurfaceFormatIndex(GLenum internalFormat, GLenum type)
+     const vk::Format &format =
+         renderer->getFormat(kIOSurfaceFormats[mFormatIndex].nativeSizedInternalFormat);
+ 
+-    // Swiftshader will use the raw pointer to the buffer referenced by the IOSurfaceRef
+-    ANGLE_TRY(mColorAttachment.initialize(displayVk, mWidth, mHeight, format, samples,
+-                                          mState.isRobustResourceInitEnabled(),
+-                                          mState.hasProtectedContent()));
++    // Zero-copy path: create the color image IOSurface-backed via VK_EXT_metal_objects so
++    // bindTexImage needs no CPU copy or GPU blit. Restricted to the common non-planar BGRA8
++    // case whose dimensions match the surface; anything else keeps the staged upload path.
++    // Robust init or non-zero memory fill would clear the imported contents, so stay staged.
++    bool canImport =
++        HasMetalObjectsExtension(renderer) &&
++        kIOSurfaceFormats[mFormatIndex].nativeSizedInternalFormat == GL_BGRA8_EXT &&
++        IOSurfaceGetPixelFormat(mIOSurface) == 'BGRA' && mPlane == 0 &&
++        static_cast<size_t>(mWidth) == IOSurfaceGetWidthOfPlane(mIOSurface, mPlane) &&
++        static_cast<size_t>(mHeight) == IOSurfaceGetHeightOfPlane(mIOSurface, mPlane) &&
++        !mState.isRobustResourceInitEnabled() && !mState.hasProtectedContent() &&
++        !renderer->getFeatures().allocateNonZeroMemory.enabled;
++
++    if (canImport)
++    {
++        VkImportMetalIOSurfaceInfoEXT importInfo = {};
++        importInfo.sType     = VK_STRUCTURE_TYPE_IMPORT_METAL_IO_SURFACE_INFO_EXT;
++        importInfo.ioSurface = mIOSurface;
++
++        if (mColorAttachment.initialize(displayVk, mWidth, mHeight, format, samples,
++                                        mState.isRobustResourceInitEnabled(),
++                                        mState.hasProtectedContent(), &importInfo,
++                                        vk::ImageAccess::ExternalPreInitialized) ==
++            angle::Result::Continue)
++        {
++            mZeroCopy = true;
++        }
++        else
++        {
++            // The driver rejected the import; release any partial image and fall back.
++            mColorAttachment.image.releaseImage(renderer);
++        }
++    }
++
++    if (!mZeroCopy)
++    {
++        // Swiftshader will use the raw pointer to the buffer referenced by the IOSurfaceRef
++        ANGLE_TRY(mColorAttachment.initialize(displayVk, mWidth, mHeight, format, samples,
++                                              mState.isRobustResourceInitEnabled(),
++                                              mState.hasProtectedContent()));
++    }
+ 
+     mColorRenderTarget.init(&mColorAttachment.image, &mColorAttachment.imageViews, nullptr, nullptr,
+                             {}, gl::LevelIndex(0), 0, 1, RenderTargetTransience::Default);
+@@ -158,6 +211,13 @@ int FindIOSurfaceFormatIndex(GLenum internalFormat, GLenum type)
+                                                gl::Texture *texture,
+                                                EGLint buffer)
+ {
++    if (mZeroCopy)
++    {
++        // The color image is the IOSurface; frames written by the producer are
++        // visible directly, so there is nothing to upload.
++        return egl::NoError();
++    }
++
+     IOSurfaceLock(mIOSurface, 0, nullptr);
+ 
+     ContextVk *contextVk   = vk::GetImpl(context);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/patches/0004-Import-IOSurface-backed-VkImage-via-VK_EXT_metal_obj.patch
+++ b/patches/0004-Import-IOSurface-backed-VkImage-via-VK_EXT_metal_obj.patch
@@ -1,4 +1,4 @@
-From 2d4e76a9c610297eb9af314f04887923948c5d9a Mon Sep 17 00:00:00 2001
+From 4338850b04973d12bf8f31c97c4c1657a3b9034c Mon Sep 17 00:00:00 2001
 From: Hiroshi Matoba <matobahiroshi@gmail.com>
 Date: Sat, 11 Jul 2026 21:52:57 +0200
 Subject: [PATCH] Import IOSurface-backed VkImage via VK_EXT_metal_objects for
@@ -16,9 +16,9 @@ import falls back to the existing staged upload path.
 ---
  src/libANGLE/renderer/vulkan/SurfaceVk.cpp    | 15 ++--
  src/libANGLE/renderer/vulkan/SurfaceVk.h      |  4 +-
- .../vulkan/mac/IOSurfaceSurfaceVkMac.h        |  4 ++
- .../vulkan/mac/IOSurfaceSurfaceVkMac.mm       | 68 +++++++++++++++++--
- 4 files changed, 81 insertions(+), 10 deletions(-)
+ .../vulkan/mac/IOSurfaceSurfaceVkMac.h        |  4 +
+ .../vulkan/mac/IOSurfaceSurfaceVkMac.mm       | 73 ++++++++++++++++++-
+ 4 files changed, 86 insertions(+), 10 deletions(-)
 
 diff --git a/src/libANGLE/renderer/vulkan/SurfaceVk.cpp b/src/libANGLE/renderer/vulkan/SurfaceVk.cpp
 index 05ffcb9..c9dbe1e 100644
@@ -93,7 +93,7 @@ index c35aaff..dba884a 100644
  
  }  // namespace rx
 diff --git a/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.mm b/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.mm
-index df1109f..ef7ff1c 100644
+index df1109f..533b22d 100644
 --- a/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.mm
 +++ b/src/libANGLE/renderer/vulkan/mac/IOSurfaceSurfaceVkMac.mm
 @@ -20,6 +20,8 @@
@@ -126,7 +126,7 @@ index df1109f..ef7ff1c 100644
  }  // anonymous namespace
  
  IOSurfaceSurfaceVkMac::IOSurfaceSurfaceVkMac(const egl::SurfaceState &state,
-@@ -118,10 +134,47 @@ int FindIOSurfaceFormatIndex(GLenum internalFormat, GLenum type)
+@@ -118,10 +134,52 @@ int FindIOSurfaceFormatIndex(GLenum internalFormat, GLenum type)
      const vk::Format &format =
          renderer->getFormat(kIOSurfaceFormats[mFormatIndex].nativeSizedInternalFormat);
  
@@ -163,7 +163,12 @@ index df1109f..ef7ff1c 100644
 +        }
 +        else
 +        {
-+            // The driver rejected the import; release any partial image and fall back.
++            // The driver rejected the import (or allocation failed); release any
++            // partial image and fall back — unless the device is lost.
++            if (renderer->isDeviceLost())
++            {
++                return angle::Result::Stop;
++            }
 +            mColorAttachment.image.releaseImage(renderer);
 +        }
 +    }
@@ -178,7 +183,7 @@ index df1109f..ef7ff1c 100644
  
      mColorRenderTarget.init(&mColorAttachment.image, &mColorAttachment.imageViews, nullptr, nullptr,
                              {}, gl::LevelIndex(0), 0, 1, RenderTargetTransience::Default);
-@@ -158,6 +211,13 @@ int FindIOSurfaceFormatIndex(GLenum internalFormat, GLenum type)
+@@ -158,6 +216,13 @@ int FindIOSurfaceFormatIndex(GLenum internalFormat, GLenum type)
                                                 gl::Texture *texture,
                                                 EGLint buffer)
  {

--- a/patches/0004-Import-IOSurface-backed-VkImage-via-VK_EXT_metal_obj.patch
+++ b/patches/0004-Import-IOSurface-backed-VkImage-via-VK_EXT_metal_obj.patch
@@ -1,4 +1,4 @@
-From 4338850b04973d12bf8f31c97c4c1657a3b9034c Mon Sep 17 00:00:00 2001
+From 7fdf0fce375b241d932d45d441ba0d8132aee947 Mon Sep 17 00:00:00 2001
 From: Hiroshi Matoba <matobahiroshi@gmail.com>
 Date: Sat, 11 Jul 2026 21:52:57 +0200
 Subject: [PATCH] Import IOSurface-backed VkImage via VK_EXT_metal_objects for
@@ -14,14 +14,14 @@ Limited to non-planar BGRA8 surfaces whose dimensions match the pbuffer.
 Any other case, robust resource init, or a driver that rejects the
 import falls back to the existing staged upload path.
 ---
- src/libANGLE/renderer/vulkan/SurfaceVk.cpp    | 15 ++--
+ src/libANGLE/renderer/vulkan/SurfaceVk.cpp    | 28 +++++--
  src/libANGLE/renderer/vulkan/SurfaceVk.h      |  4 +-
  .../vulkan/mac/IOSurfaceSurfaceVkMac.h        |  4 +
  .../vulkan/mac/IOSurfaceSurfaceVkMac.mm       | 73 ++++++++++++++++++-
- 4 files changed, 86 insertions(+), 10 deletions(-)
+ 4 files changed, 99 insertions(+), 10 deletions(-)
 
 diff --git a/src/libANGLE/renderer/vulkan/SurfaceVk.cpp b/src/libANGLE/renderer/vulkan/SurfaceVk.cpp
-index 05ffcb9..c9dbe1e 100644
+index 05ffcb9..c38d347 100644
 --- a/src/libANGLE/renderer/vulkan/SurfaceVk.cpp
 +++ b/src/libANGLE/renderer/vulkan/SurfaceVk.cpp
 @@ -182,6 +182,8 @@ angle::Result InitImageHelper(DisplayVk *displayVk,
@@ -33,8 +33,23 @@ index 05ffcb9..c9dbe1e 100644
                                vk::ImageHelper *imageHelper)
  {
      const angle::Format &textureFormat = vkFormat.getActualRenderableImageFormat();
-@@ -215,9 +217,9 @@ angle::Result InitImageHelper(DisplayVk *displayVk,
+@@ -213,11 +215,24 @@ angle::Result InitImageHelper(DisplayVk *displayVk,
+ 
+     VkImageCreateFlags imageCreateFlags =
          hasProtectedContent ? VK_IMAGE_CREATE_PROTECTED_BIT : vk::kVkImageCreateFlagsNone;
++
++    // initExternal skips deriving the format-list pNext (sRGB reinterpretation support) when an
++    // external create info is provided; chain it in front so imported images behave like
++    // ordinary ones.
++    VkImageFormatListCreateInfoKHR imageFormatListInfoStorage;
++    vk::ImageHelper::ImageListFormats imageListFormatsStorage;
++    if (externalImageCreateInfo != nullptr)
++    {
++        externalImageCreateInfo = vk::ImageHelper::DeriveCreateInfoPNext(
++            displayVk, usage, renderableFormatId, externalImageCreateInfo,
++            &imageFormatListInfoStorage, &imageListFormatsStorage, &imageCreateFlags);
++    }
++
      ANGLE_TRY(imageHelper->initExternal(
          displayVk, gl::TextureType::_2D, extents, vkFormat.getIntendedFormatID(),
 -        renderableFormatId, samples, usage, imageCreateFlags, vk::ImageAccess::Undefined, nullptr,
@@ -46,7 +61,7 @@ index 05ffcb9..c9dbe1e 100644
  
      return angle::Result::Continue;
  }
-@@ -631,10 +633,13 @@ angle::Result OffscreenSurfaceVk::AttachmentImage::initialize(DisplayVk *display
+@@ -631,10 +646,13 @@ angle::Result OffscreenSurfaceVk::AttachmentImage::initialize(DisplayVk *display
                                                                const vk::Format &vkFormat,
                                                                GLint samples,
                                                                bool isRobustResourceInitEnabled,


### PR DESCRIPTION
## Summary
- Adds `patches/0004-Import-IOSurface-backed-VkImage-via-VK_EXT_metal_obj.patch`: on the Vulkan/MoltenVK backend, the IOSurface pbuffer's color `VkImage` is now created with `VkImportMetalIOSurfaceInfoEXT` chained into `VkImageCreateInfo`, so the image is IOSurface-backed from creation and `bindTexImage` becomes a no-op — no `IOSurfaceLock`, no CPU memcpy, no per-bind `vkCmdCopyBufferToImage` (several ms/frame saved at 2160p60).
- Zero-copy is gated to the common case: VK_EXT_metal_objects enabled (patch 0002), non-planar `'BGRA'` IOSurface with BGRA8 format, dimensions matching the pbuffer, no robust-init/protected-content/non-zero-fill. Everything else — or a driver that rejects the import — falls back to the existing staged upload path.
- Touches `IOSurfaceSurfaceVkMac.{h,mm}` plus two defaulted pass-through params in `SurfaceVk.{h,cpp}` (`externalImageCreateInfo`, `initialAccess`); all other callers unchanged. Complements patch 0001 (skip readback on release) — the IOSurface path is now zero-copy in both directions.
- Updates CLAUDE.md's patch list (documents 0003 and 0004).

## Test plan
- [ ] `./mac-local-build.sh` completes; all four variants build (Debug/Release × arm64/x64) — Debug+Release arm64 verified locally, series `git am`s cleanly on pristine `78f1066e99`
- [ ] Run Isadora with a 2160p60 Syphon producer: Metal System Trace shows no per-bind `vkCmdCopyBufferToImage`, ~0 CPU in `bindTexImage`
- [ ] Content renders identically (colors/orientation) at 2160p/1080p/720p
- [ ] Fallback: older MoltenVK (without VK_EXT_metal_objects) still renders via the staged path

Fixes #3